### PR TITLE
[WIP] Update for Micropython v1.25

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "secp256k1"]
 	path = secp256k1
-	url = https://github.com/ElementsProject/secp256k1-zkp.git
+	url = https://github.com/BlockstreamResearch/secp256k1-zkp.git

--- a/micropython.mk
+++ b/micropython.mk
@@ -7,4 +7,4 @@ SRC_USERMOD += $(SECP256K1_MODULE_DIR)/mpy/config/ext_callbacks.c
 SRC_USERMOD += $(SECP256K1_MODULE_DIR)/mpy/libsecp256k1.c
 
 # We can add our module folder to include paths if needed
-CFLAGS_USERMOD += -I$(SECP256K1_MODULE_DIR)/secp256k1 -I$(SECP256K1_MODULE_DIR)/secp256k1/src -I$(SECP256K1_MODULE_DIR)/mpy/config -DHAVE_CONFIG_H -Wno-unused-function -Wno-error -DMODULE_SECP256K1_ENABLED=1
+CFLAGS_USERMOD += -I$(SECP256K1_MODULE_DIR)/secp256k1 -I$(SECP256K1_MODULE_DIR)/secp256k1/src -I$(SECP256K1_MODULE_DIR)/mpy/config -DHAVE_CONFIG_H -Wno-error=unused-function -Wno-unused-function -DMODULE_SECP256K1_ENABLED=1 -w

--- a/mpy/config/rangeproof_preallocated/rangeproof_preallocated_impl.h
+++ b/mpy/config/rangeproof_preallocated/rangeproof_preallocated_impl.h
@@ -2,7 +2,6 @@
 #define _SECP256K1_RANGEPROOF_PREALLOCATED_IMPL_H_
 
 SECP256K1_INLINE static int secp256k1_rangeproof_sign_preallocated_impl(
- const secp256k1_ecmult_context* ecmult_ctx,
  const secp256k1_ecmult_gen_context* ecmult_gen_ctx,
  unsigned char *proof, size_t *plen, uint64_t min_value,
  const secp256k1_ge *commit, const unsigned char *blind, const unsigned char *nonce, int exp, int min_bits, uint64_t value,
@@ -153,7 +152,7 @@ SECP256K1_INLINE static int secp256k1_rangeproof_sign_preallocated_impl(
         secp256k1_sha256_write(&sha256_m, extra_commit, extra_commit_len);
     }
     secp256k1_sha256_finalize(&sha256_m, tmp);
-    if (!secp256k1_borromean_sign(ecmult_ctx, ecmult_gen_ctx, &proof[len], s, pubs, k, sec, rsizes, secidx, rings, tmp, 32)) {
+    if (!secp256k1_borromean_sign(ecmult_gen_ctx, &proof[len], s, pubs, k, sec, rsizes, secidx, rings, tmp, 32)) {
         return 0;
     }
     len += 32;
@@ -182,11 +181,10 @@ int secp256k1_rangeproof_sign_preallocated(const secp256k1_context* ctx, unsigne
     ARG_CHECK(message != NULL || msg_len == 0);
     ARG_CHECK(extra_commit != NULL || extra_commit_len == 0);
     ARG_CHECK(gen != NULL);
-    ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     secp256k1_pedersen_commitment_load(&commitp, commit);
     secp256k1_generator_load(&genp, gen);
-    return secp256k1_rangeproof_sign_preallocated_impl(&ctx->ecmult_ctx, &ctx->ecmult_gen_ctx,
+    return secp256k1_rangeproof_sign_preallocated_impl(&ctx->ecmult_gen_ctx,
      proof, plen, min_value, &commitp, blind, nonce, exp, min_bits, value, message, msg_len, extra_commit, extra_commit_len, &genp,
      preallocated_ptr, allocated_len);
 }
@@ -326,8 +324,7 @@ SECP256K1_INLINE static int secp256k1_rangeproof_rewind_preallocated_inner(secp2
     return 1;
 }
 
-SECP256K1_INLINE static int secp256k1_rangeproof_verify_preallocated_impl(const secp256k1_ecmult_context* ecmult_ctx,
- const secp256k1_ecmult_gen_context* ecmult_gen_ctx,
+SECP256K1_INLINE static int secp256k1_rangeproof_verify_preallocated_impl(const secp256k1_ecmult_gen_context* ecmult_gen_ctx,
  unsigned char *blindout, uint64_t *value_out, unsigned char *message_out, size_t *outlen, const unsigned char *nonce,
  uint64_t *min_value, uint64_t *max_value, const secp256k1_ge *commit, const unsigned char *proof, size_t plen, const unsigned char *extra_commit, size_t extra_commit_len, const secp256k1_ge* genp,
  void * preallocated_ptr, intptr_t allocated_len) {
@@ -414,7 +411,7 @@ SECP256K1_INLINE static int secp256k1_rangeproof_verify_preallocated_impl(const 
     }
     for(i = 0; i < rings - 1; i++) {
         secp256k1_fe fe;
-        if (!secp256k1_fe_set_b32(&fe, &proof[offset]) ||
+        if (!secp256k1_fe_set_b32_limit(&fe, &proof[offset]) ||
             !secp256k1_ge_set_xquad(&c, &fe)) {
             return 0;
         }
@@ -454,7 +451,7 @@ SECP256K1_INLINE static int secp256k1_rangeproof_verify_preallocated_impl(const 
         secp256k1_sha256_write(&sha256_m, extra_commit, extra_commit_len);
     }
     secp256k1_sha256_finalize(&sha256_m, m);
-    ret = secp256k1_borromean_verify(ecmult_ctx, nonce ? evalues : NULL, e0, s, pubs, rsizes, rings, m, 32);
+    ret = secp256k1_borromean_verify(nonce ? evalues : NULL, e0, s, pubs, rsizes, rings, m, 32);
     if (ret && nonce) {
         /* Given the nonce, try rewinding the witness to recover its initial state. */
         secp256k1_scalar blind;
@@ -504,11 +501,10 @@ int secp256k1_rangeproof_rewind_preallocated(const secp256k1_context* ctx,
     ARG_CHECK(nonce != NULL);
     ARG_CHECK(extra_commit != NULL || extra_commit_len == 0);
     ARG_CHECK(gen != NULL);
-    ARG_CHECK(secp256k1_ecmult_context_is_built(&ctx->ecmult_ctx));
     ARG_CHECK(secp256k1_ecmult_gen_context_is_built(&ctx->ecmult_gen_ctx));
     secp256k1_pedersen_commitment_load(&commitp, commit);
     secp256k1_generator_load(&genp, gen);
-    return secp256k1_rangeproof_verify_preallocated_impl(&ctx->ecmult_ctx, &ctx->ecmult_gen_ctx,
+    return secp256k1_rangeproof_verify_preallocated_impl(&ctx->ecmult_gen_ctx,
      blind_out, value_out, message_out, outlen, nonce, min_value, max_value, &commitp, proof, plen, extra_commit, extra_commit_len, &genp,
      preallocated_ptr, allocated_len);
 }

--- a/mpy/config/secp256k1_build.c
+++ b/mpy/config/secp256k1_build.c
@@ -1,5 +1,9 @@
 // includes libsecp with preallocated rangeproof functions
+#include "libsecp256k1-config.h"
 #include "secp256k1.c"
+#include "precomputed_ecmult.c"
+#include "precomputed_ecmult_gen.c"
+
 #ifdef ENABLE_MODULE_RANGEPROOF
 #ifdef ENABLE_MODULE_RANGEPROOF_PREALLOCATED
 #include "rangeproof_preallocated/rangeproof_preallocated_impl.h"

--- a/mpy/libsecp256k1.c
+++ b/mpy/libsecp256k1.c
@@ -27,8 +27,8 @@
 // global context
 #define PREALLOCATED_CTX_SIZE 880 // 440 for 32-bit. FIXME: autodetect
 
-STATIC unsigned char preallocated_ctx[PREALLOCATED_CTX_SIZE];
-STATIC secp256k1_context * ctx = NULL;
+static unsigned char preallocated_ctx[PREALLOCATED_CTX_SIZE];
+static secp256k1_context * ctx = NULL;
 
 void maybe_init_ctx(){
     if(ctx != NULL){
@@ -39,15 +39,15 @@ void maybe_init_ctx(){
 }
 
 
-STATIC mp_obj_t usecp256k1_context_preallocated_size(){
+static mp_obj_t usecp256k1_context_preallocated_size(){
     size_t size = secp256k1_context_preallocated_size(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
     return mp_obj_new_int_from_ull(size);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(usecp256k1_context_preallocated_size_obj, usecp256k1_context_preallocated_size);
+static MP_DEFINE_CONST_FUN_OBJ_0(usecp256k1_context_preallocated_size_obj, usecp256k1_context_preallocated_size);
 
 
 // randomize context using 32-byte seed
-STATIC mp_obj_t usecp256k1_context_randomize(const mp_obj_t seed){
+static mp_obj_t usecp256k1_context_randomize(const mp_obj_t seed){
     maybe_init_ctx();
     mp_buffer_info_t seedbuf;
     mp_get_buffer_raise(seed, &seedbuf, MP_BUFFER_READ);
@@ -62,10 +62,10 @@ STATIC mp_obj_t usecp256k1_context_randomize(const mp_obj_t seed){
     }
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_context_randomize_obj, usecp256k1_context_randomize);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_context_randomize_obj, usecp256k1_context_randomize);
 
 // create public key from private key
-STATIC mp_obj_t usecp256k1_ec_pubkey_create(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ec_pubkey_create(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t secretbuf;
     mp_get_buffer_raise(arg, &secretbuf, MP_BUFFER_READ);
@@ -86,10 +86,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_create(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_create_obj, usecp256k1_ec_pubkey_create);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_create_obj, usecp256k1_ec_pubkey_create);
 
 // parse sec-encoded public key
-STATIC mp_obj_t usecp256k1_ec_pubkey_parse(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ec_pubkey_parse(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(arg, &secbuf, MP_BUFFER_READ);
@@ -125,10 +125,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_parse(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_parse_obj, usecp256k1_ec_pubkey_parse);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_parse_obj, usecp256k1_ec_pubkey_parse);
 
 // serialize public key
-STATIC mp_obj_t usecp256k1_ec_pubkey_serialize(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_ec_pubkey_serialize(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(args[0], &pubbuf, MP_BUFFER_READ);
@@ -155,10 +155,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_serialize(mp_uint_t n_args, const mp_obj_t 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_serialize_obj, 1, usecp256k1_ec_pubkey_serialize);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_serialize_obj, 1, usecp256k1_ec_pubkey_serialize);
 
 // parse compact ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_compact(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ecdsa_signature_parse_compact(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -179,10 +179,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_compact(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_compact_obj, usecp256k1_ecdsa_signature_parse_compact);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_compact_obj, usecp256k1_ecdsa_signature_parse_compact);
 
 // parse der ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_der(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ecdsa_signature_parse_der(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -199,10 +199,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_der(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_der_obj, usecp256k1_ecdsa_signature_parse_der);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_der_obj, usecp256k1_ecdsa_signature_parse_der);
 
 // serialize der ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_der(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ecdsa_signature_serialize_der(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -226,10 +226,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_der(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_der_obj, usecp256k1_ecdsa_signature_serialize_der);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_der_obj, usecp256k1_ecdsa_signature_serialize_der);
 
 // serialize compact ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_compact(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ecdsa_signature_serialize_compact(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -245,10 +245,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_compact(const mp_obj_t arg)
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_compact_obj, usecp256k1_ecdsa_signature_serialize_compact);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_compact_obj, usecp256k1_ecdsa_signature_serialize_compact);
 
 // verify ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t msgarg, const mp_obj_t pubkeyarg){
+static mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t msgarg, const mp_obj_t pubkeyarg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(sigarg, &buf, MP_BUFFER_READ);
@@ -282,10 +282,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t ms
     return mp_const_false;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_ecdsa_verify_obj, usecp256k1_ecdsa_verify);
+static MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_ecdsa_verify_obj, usecp256k1_ecdsa_verify);
 
 // normalize ecdsa signature
-STATIC mp_obj_t usecp256k1_ecdsa_signature_normalize(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ecdsa_signature_normalize(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -303,10 +303,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_normalize(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_normalize_obj, usecp256k1_ecdsa_signature_normalize);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_normalize_obj, usecp256k1_ecdsa_signature_normalize);
 
 // same as secp256k1_nonce_function_rfc6979
-STATIC mp_obj_t usecp256k1_nonce_function_default(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_nonce_function_default(mp_uint_t n_args, const mp_obj_t *args){
     mp_buffer_info_t msgbuf;
     mp_get_buffer_raise(args[0], &msgbuf, MP_BUFFER_READ);
     if(msgbuf.len != 32){
@@ -350,12 +350,12 @@ STATIC mp_obj_t usecp256k1_nonce_function_default(mp_uint_t n_args, const mp_obj
     }
     return mp_obj_new_bytes_from_vstr(&nonce);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_nonce_function_default_obj, 2, usecp256k1_nonce_function_default);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_nonce_function_default_obj, 2, usecp256k1_nonce_function_default);
 
-STATIC mp_obj_t mp_nonce_callback = NULL;
-STATIC mp_obj_t mp_nonce_data = NULL;
+static mp_obj_t mp_nonce_callback = NULL;
+static mp_obj_t mp_nonce_data = NULL;
 
-STATIC int usecp256k1_nonce_function(
+static int usecp256k1_nonce_function(
     unsigned char *nonce32,
     const unsigned char *msg32,
     const unsigned char *key32,
@@ -408,7 +408,7 @@ STATIC int usecp256k1_nonce_function(
 }
 
 // msg, secret, [callback, data]
-STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
@@ -459,10 +459,10 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_obj, 2, usecp256k1_ecdsa_sign);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_obj, 2, usecp256k1_ecdsa_sign);
 
 // verify secret key
-STATIC mp_obj_t usecp256k1_ec_seckey_verify(const mp_obj_t arg){
+static mp_obj_t usecp256k1_ec_seckey_verify(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -478,10 +478,10 @@ STATIC mp_obj_t usecp256k1_ec_seckey_verify(const mp_obj_t arg){
     return mp_const_false;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_seckey_verify_obj, usecp256k1_ec_seckey_verify);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_seckey_verify_obj, usecp256k1_ec_seckey_verify);
 
 // return N - secret key
-STATIC mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
+static mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -502,10 +502,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_privkey_negate_obj, usecp256k1_ec_privkey_negate);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_privkey_negate_obj, usecp256k1_ec_privkey_negate);
 
 // return neg of pubkey
-STATIC mp_obj_t usecp256k1_ec_pubkey_negate(mp_obj_t arg){
+static mp_obj_t usecp256k1_ec_pubkey_negate(mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -526,10 +526,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_negate(mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_negate_obj, usecp256k1_ec_pubkey_negate);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_negate_obj, usecp256k1_ec_pubkey_negate);
 
 // tweak private key in place
-STATIC mp_obj_t usecp256k1_ec_privkey_tweak_add(mp_obj_t privarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_privkey_tweak_add(mp_obj_t privarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
@@ -553,10 +553,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_tweak_add(mp_obj_t privarg, const mp_obj_t
     return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_tweak_add_obj, usecp256k1_ec_privkey_tweak_add);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_tweak_add_obj, usecp256k1_ec_privkey_tweak_add);
 
 // add private key
-STATIC mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
@@ -584,10 +584,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweak
     return mp_obj_new_bytes_from_vstr(&priv2);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_add_obj, usecp256k1_ec_privkey_add);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_add_obj, usecp256k1_ec_privkey_add);
 
 // tweak public key in place (add tweak * Generator)
-STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_add(mp_obj_t pubarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_pubkey_tweak_add(mp_obj_t pubarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
@@ -614,10 +614,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_add(mp_obj_t pubarg, const mp_obj_t t
     return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_tweak_add_obj, usecp256k1_ec_pubkey_tweak_add);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_tweak_add_obj, usecp256k1_ec_pubkey_tweak_add);
 
 // add tweak * Generator
-STATIC mp_obj_t usecp256k1_ec_pubkey_add(mp_obj_t pubarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_pubkey_add(mp_obj_t pubarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
@@ -647,10 +647,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_add(mp_obj_t pubarg, const mp_obj_t tweakar
     return mp_obj_new_bytes_from_vstr(&pubbuf2);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_add_obj, usecp256k1_ec_pubkey_add);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_add_obj, usecp256k1_ec_pubkey_add);
 
 // tweak private key in place (multiply by tweak)
-STATIC mp_obj_t usecp256k1_ec_privkey_tweak_mul(mp_obj_t privarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_privkey_tweak_mul(mp_obj_t privarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
@@ -674,10 +674,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_tweak_mul(mp_obj_t privarg, const mp_obj_t
     return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_tweak_mul_obj, usecp256k1_ec_privkey_tweak_mul);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_tweak_mul_obj, usecp256k1_ec_privkey_tweak_mul);
 
 // tweak public key in place (multiply by tweak)
-STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_mul(mp_obj_t pubarg, const mp_obj_t tweakarg){
+static mp_obj_t usecp256k1_ec_pubkey_tweak_mul(mp_obj_t pubarg, const mp_obj_t tweakarg){
     maybe_init_ctx();
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
@@ -704,10 +704,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_mul(mp_obj_t pubarg, const mp_obj_t t
     return mp_const_none;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_tweak_mul_obj, usecp256k1_ec_pubkey_tweak_mul);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_tweak_mul_obj, usecp256k1_ec_pubkey_tweak_mul);
 
 // adds public keys
-STATIC mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     secp256k1_pubkey pubkey;
     secp256k1_pubkey ** pubkeys;
@@ -741,11 +741,11 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *a
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_combine_obj, 2, usecp256k1_ec_pubkey_combine);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_combine_obj, 2, usecp256k1_ec_pubkey_combine);
 
 /**************************** schnorrsig ****************************/
 
-STATIC mp_obj_t usecp256k1_xonly_pubkey_from_pubkey(mp_obj_t arg){
+static mp_obj_t usecp256k1_xonly_pubkey_from_pubkey(mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -770,10 +770,10 @@ STATIC mp_obj_t usecp256k1_xonly_pubkey_from_pubkey(mp_obj_t arg){
     return mp_obj_new_tuple(2, items);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_xonly_pubkey_from_pubkey_obj, usecp256k1_xonly_pubkey_from_pubkey);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_xonly_pubkey_from_pubkey_obj, usecp256k1_xonly_pubkey_from_pubkey);
 
 
-STATIC mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj_t msgarg, const mp_obj_t pubkeyarg){
+static mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj_t msgarg, const mp_obj_t pubkeyarg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(sigarg, &buf, MP_BUFFER_READ);
@@ -800,17 +800,17 @@ STATIC mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj
     secp256k1_xonly_pubkey pub;
     memcpy(pub.data, buf.buf, 64);
 
-    int res = secp256k1_schnorrsig_verify(ctx, sig, msg, &pub);
+    int res = secp256k1_schnorrsig_verify(ctx, sig, msg, sizeof(msg), &pub);
     if(res){
         return mp_const_true;
     }
     return mp_const_false;
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_schnorrsig_verify_obj, usecp256k1_schnorrsig_verify);
+static MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_schnorrsig_verify_obj, usecp256k1_schnorrsig_verify);
 
 
-STATIC mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
+static mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -830,11 +830,11 @@ STATIC mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_keypair_create_obj, usecp256k1_keypair_create);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_keypair_create_obj, usecp256k1_keypair_create);
 
 
 // msg, secret, [callback, data]
-STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
@@ -871,7 +871,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
 
     int res=0;
     if(n_args == 2){
-        res = secp256k1_schnorrsig_sign(ctx, sig, msgbuf.buf, (secp256k1_keypair *)keypair, NULL, NULL);
+        res = secp256k1_schnorrsig_sign32(ctx, sig, msgbuf.buf, (secp256k1_keypair *)keypair, NULL);
     }else if(n_args >= 3){
         mp_nonce_callback = args[2];
         if(n_args > 3){
@@ -882,7 +882,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
             }
             data = databuf.buf;
         }
-        res = secp256k1_schnorrsig_sign(ctx, sig, msgbuf.buf, (secp256k1_keypair *)keypair, NULL, data);
+        res = secp256k1_schnorrsig_sign32(ctx, sig, msgbuf.buf, (secp256k1_keypair *)keypair, data);
     }
     if(!res){
         mp_raise_ValueError(MP_ERROR_TEXT("Failed to sign"));
@@ -896,12 +896,12 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_schnorrsig_sign_obj, 2, usecp256k1_schnorrsig_sign);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_schnorrsig_sign_obj, 2, usecp256k1_schnorrsig_sign);
 
 /**************************** recoverable ***************************/
 
 // msg, secret, [callback, data]
-STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
@@ -952,11 +952,11 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj
 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_recoverable_obj, 2, usecp256k1_ecdsa_sign_recoverable);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_recoverable_obj, 2, usecp256k1_ecdsa_sign_recoverable);
 
 /******************************* zkp ********************************/
 
-STATIC mp_obj_t usecp256k1_generator_generate_blinded(const mp_obj_t assetarg, const mp_obj_t abfarg){
+static mp_obj_t usecp256k1_generator_generate_blinded(const mp_obj_t assetarg, const mp_obj_t abfarg){
     maybe_init_ctx();
     mp_buffer_info_t assetbuf;
     mp_get_buffer_raise(assetarg, &assetbuf, MP_BUFFER_READ);
@@ -985,9 +985,9 @@ STATIC mp_obj_t usecp256k1_generator_generate_blinded(const mp_obj_t assetarg, c
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_generator_generate_blinded_obj, usecp256k1_generator_generate_blinded);
+static MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_generator_generate_blinded_obj, usecp256k1_generator_generate_blinded);
 
-STATIC mp_obj_t usecp256k1_generator_generate(const mp_obj_t assetarg){
+static mp_obj_t usecp256k1_generator_generate(const mp_obj_t assetarg){
     maybe_init_ctx();
     mp_buffer_info_t assetbuf;
     mp_get_buffer_raise(assetarg, &assetbuf, MP_BUFFER_READ);
@@ -1009,10 +1009,10 @@ STATIC mp_obj_t usecp256k1_generator_generate(const mp_obj_t assetarg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_generate_obj, usecp256k1_generator_generate);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_generate_obj, usecp256k1_generator_generate);
 
 // serialize generator
-STATIC mp_obj_t usecp256k1_generator_serialize(const mp_obj_t arg){
+static mp_obj_t usecp256k1_generator_serialize(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -1028,9 +1028,9 @@ STATIC mp_obj_t usecp256k1_generator_serialize(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_serialize_obj, usecp256k1_generator_serialize);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_serialize_obj, usecp256k1_generator_serialize);
 
-STATIC mp_obj_t usecp256k1_generator_parse(const mp_obj_t arg){
+static mp_obj_t usecp256k1_generator_parse(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -1050,10 +1050,10 @@ STATIC mp_obj_t usecp256k1_generator_parse(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_parse_obj, usecp256k1_generator_parse);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_parse_obj, usecp256k1_generator_parse);
 
 // pedersen_commit(value_blinding_factor, value, gen)
-STATIC mp_obj_t usecp256k1_pedersen_commit(const mp_obj_t blindarg, mp_obj_t valuearg, const mp_obj_t genarg){
+static mp_obj_t usecp256k1_pedersen_commit(const mp_obj_t blindarg, mp_obj_t valuearg, const mp_obj_t genarg){
     maybe_init_ctx();
     mp_buffer_info_t blindbuf;
     mp_get_buffer_raise(blindarg, &blindbuf, MP_BUFFER_READ);
@@ -1109,9 +1109,9 @@ STATIC mp_obj_t usecp256k1_pedersen_commit(const mp_obj_t blindarg, mp_obj_t val
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_pedersen_commit_obj, usecp256k1_pedersen_commit);
+static MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_pedersen_commit_obj, usecp256k1_pedersen_commit);
 
-STATIC mp_obj_t usecp256k1_pedersen_commitment_serialize(const mp_obj_t arg){
+static mp_obj_t usecp256k1_pedersen_commitment_serialize(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -1127,10 +1127,10 @@ STATIC mp_obj_t usecp256k1_pedersen_commitment_serialize(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_serialize_obj, usecp256k1_pedersen_commitment_serialize);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_serialize_obj, usecp256k1_pedersen_commitment_serialize);
 
 
-STATIC mp_obj_t usecp256k1_pedersen_commitment_parse(const mp_obj_t arg){
+static mp_obj_t usecp256k1_pedersen_commitment_parse(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
@@ -1150,7 +1150,7 @@ STATIC mp_obj_t usecp256k1_pedersen_commitment_parse(const mp_obj_t arg){
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_parse_obj, usecp256k1_pedersen_commitment_parse);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_parse_obj, usecp256k1_pedersen_commitment_parse);
 
 uint64_t get_uint64(mp_obj_t arg){
     uint64_t value = 0;
@@ -1175,7 +1175,7 @@ uint64_t get_uint64(mp_obj_t arg){
 }
 
 // vals, abfs, vbfs, psbtv.num_inputs
-STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_obj_list_t *vals = MP_OBJ_TO_PTR(args[0]);
     mp_obj_list_t *abfs = MP_OBJ_TO_PTR(args[1]);
@@ -1243,12 +1243,12 @@ STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, 
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_pedersen_blind_generator_blind_sum_obj, 4, usecp256k1_pedersen_blind_generator_blind_sum);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_pedersen_blind_generator_blind_sum_obj, 4, usecp256k1_pedersen_blind_generator_blind_sum);
 
 // surjection proofs
 
 // surjectionproof_initialize(in_assets, asset, seed, tags_to_use=None, iterations=100)
-STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     secp256k1_fixed_asset_tag * in_assets_ptr = NULL;
     mp_obj_list_t *in_assets = NULL;
@@ -1316,12 +1316,12 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp
     items[1] = mp_obj_new_int_from_ull(input_index);
     return mp_obj_new_tuple(2, items);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_initialize_obj, 3, usecp256k1_surjectionproof_initialize);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_initialize_obj, 3, usecp256k1_surjectionproof_initialize);
 
 // surjectionproof_initialize_preallocated(proofptr, prooflen, in_assets, asset, seed, tags_to_use=None, iterations=100)
 // proofptr is a pointer to preallocated memory and prooflen is the length of availble memory
 // returns a tuple: (used prooflen, in_index)
-STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     intptr_t proofptr = get_uint64(args[0]);
     size_t prooflen = get_uint64(args[1]);
@@ -1392,10 +1392,10 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_a
     items[1] = mp_obj_new_int_from_ull(input_index);
     return mp_obj_new_tuple(2, items);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_initialize_preallocated_obj, 3, usecp256k1_surjectionproof_initialize_preallocated);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_initialize_preallocated_obj, 3, usecp256k1_surjectionproof_initialize_preallocated);
 
 // surjectionproof_generate(proof, in_idx, in_tags, out_tag, in_abf, out_abf)
-STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_buffer_info_t proof;
     secp256k1_surjectionproof * ptr = NULL;
@@ -1448,10 +1448,10 @@ STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_o
     }
     return args[0];
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_generate_obj, 6, usecp256k1_surjectionproof_generate);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_surjectionproof_generate_obj, 6, usecp256k1_surjectionproof_generate);
 
 // surjectionproof_serialize(proof) - proof is either a buffer or a pointer
-STATIC mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
+static mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
     maybe_init_ctx();
     mp_buffer_info_t proof;
     secp256k1_surjectionproof * ptr;
@@ -1479,10 +1479,10 @@ STATIC mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
     }
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_surjectionproof_serialize_obj, usecp256k1_surjectionproof_serialize);
+static MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_surjectionproof_serialize_obj, usecp256k1_surjectionproof_serialize);
 
 // rangeproof_sign(nonce, value, value_commitment, vbf, message, extra, gen, min_value=1, exp=0, min_bits=52)
-STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 7){
         mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least 7 arguments"));
@@ -1567,11 +1567,11 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_obj, 7, usecp256k1_rangeproof_sign);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_obj, 7, usecp256k1_rangeproof_sign);
 
 // rangeproof_sign_to(stream, mem_ptr, mem_len,
 //                    nonce, value, value_commitment, vbf, message, extra, gen, min_value=1, exp=0, min_bits=52)
-STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 10){
         mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least 10 arguments"));
@@ -1669,11 +1669,11 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     return mp_obj_new_int_from_ull(prooflen);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_to_obj, 10, usecp256k1_rangeproof_sign_to);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_to_obj, 10, usecp256k1_rangeproof_sign_to);
 
 
 // rangeproof_rewind(proof, nonce, value_commitment, script_pubkey, generator)
-STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 5){
         mp_raise_ValueError(MP_ERROR_TEXT("Function requires 5 arguments"));
@@ -1750,10 +1750,10 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *a
     return mp_obj_new_tuple(5, items);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_rewind_obj, 5, usecp256k1_rangeproof_rewind);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_rewind_obj, 5, usecp256k1_rangeproof_rewind);
 
 // rangeproof_verify(proof, value_commitment, script_pubkey, generator)
-STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 4){
         mp_raise_ValueError(MP_ERROR_TEXT("Function requires 4 arguments"));
@@ -1799,10 +1799,10 @@ STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *a
     return mp_obj_new_tuple(2, items);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_verify_obj, 4, usecp256k1_rangeproof_verify);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_verify_obj, 4, usecp256k1_rangeproof_verify);
 
 // rangeproof_rewind_from(stream, len, memptr, memlen, nonce, value_commitment, script_pubkey, generator)
-STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj_t *args){
+static mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 8){
         mp_raise_ValueError(MP_ERROR_TEXT("Function requires 8 arguments"));
@@ -1915,12 +1915,12 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
     return mp_obj_new_tuple(5, items);
 }
 
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_rewind_from_obj, 8, usecp256k1_rangeproof_rewind_from);
+static MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_rewind_from_obj, 8, usecp256k1_rangeproof_rewind_from);
 
 
 /****************************** MODULE ******************************/
 
-STATIC const mp_rom_map_elem_t secp256k1_module_globals_table[] = {
+static const mp_rom_map_elem_t secp256k1_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_secp256k1) },
     { MP_ROM_QSTR(MP_QSTR_context_randomize), MP_ROM_PTR(&usecp256k1_context_randomize_obj) },
     { MP_ROM_QSTR(MP_QSTR_context_preallocated_size), MP_ROM_PTR(&usecp256k1_context_preallocated_size_obj) },
@@ -1980,7 +1980,7 @@ STATIC const mp_rom_map_elem_t secp256k1_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_surjectionproof_serialize), MP_ROM_PTR(&usecp256k1_surjectionproof_serialize_obj) },
 
 };
-STATIC MP_DEFINE_CONST_DICT(secp256k1_module_globals, secp256k1_module_globals_table);
+static MP_DEFINE_CONST_DICT(secp256k1_module_globals, secp256k1_module_globals_table);
 
 // Define module object.
 const mp_obj_module_t secp256k1_user_cmodule = {

--- a/mpy/libsecp256k1.c
+++ b/mpy/libsecp256k1.c
@@ -494,7 +494,7 @@ STATIC mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
     vstr_init_len(&vstr, 32);
     memcpy((byte*)vstr.buf, buf.buf, 32);
 
-    int res = secp256k1_ec_privkey_negate(ctx, vstr.buf);
+    int res = secp256k1_ec_privkey_negate(ctx, (unsigned char *)vstr.buf);
     if(!res){ // never happens according to the API
         mp_raise_ValueError(MP_ERROR_TEXT("Failed to negate the private key"));
         return mp_const_none;
@@ -576,7 +576,7 @@ STATIC mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweak
     vstr_init_len(&priv2, 32);
     memcpy((byte*)priv2.buf, privbuf.buf, 32);
 
-    int res = secp256k1_ec_privkey_tweak_add(ctx, priv2.buf, tweakbuf.buf);
+    int res = secp256k1_ec_privkey_tweak_add(ctx, (unsigned char *)priv2.buf, tweakbuf.buf);
     if(!res){ // never happens according to the API
         mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the private key"));
         return mp_const_none;
@@ -821,7 +821,6 @@ STATIC mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
 
     vstr_t vstr;
     vstr_init_len(&vstr, 96);
-    int parity = 0;
 
     int res = secp256k1_keypair_create(ctx, (secp256k1_keypair *)vstr.buf, buf.buf);
     if(!res){
@@ -1228,9 +1227,9 @@ STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, 
         mp_get_buffer(vbfs->items[i], &buf, MP_BUFFER_READ);
         if(i == n_total-1){
             memcpy(vstr.buf, buf.buf, 32);
-            bfactors[i] = vstr.buf;
+            bfactors[i] = (unsigned char *)vstr.buf;
         }else{
-            bfactors[i] = buf.buf;
+            bfactors[i] = (unsigned char *)buf.buf;
         }
     }
     int res = secp256k1_pedersen_blind_generator_blind_sum(ctx, value, gens, bfactors, n_total, n_inputs);
@@ -1470,7 +1469,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
     vstr_init_len(&vstr, l);
     size_t l0 = l;
 
-    int res = secp256k1_surjectionproof_serialize(ctx, vstr.buf, &l, ptr);
+    int res = secp256k1_surjectionproof_serialize(ctx, (unsigned char *)vstr.buf, &l, ptr);
     if(!res){
         mp_raise_ValueError(MP_ERROR_TEXT("Failed to serialize surj proof"));
         return mp_const_none;
@@ -1557,7 +1556,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     vstr_t vstr;
     size_t prooflen = 5200;
     vstr_init_len(&vstr, 5200);
-    int res = secp256k1_rangeproof_sign(ctx, vstr.buf, &prooflen,
+    int res = secp256k1_rangeproof_sign(ctx, (unsigned char *)vstr.buf, &prooflen,
                 min_value, &commit, vbf.buf, nonce.buf,
                 exp, min_bits, value, msg.buf, msg.len, extra.buf, extra.len, &gen);
     if(!res){
@@ -1722,8 +1721,8 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *a
     uint64_t min_value;
     uint64_t max_value;
 
-    int res = secp256k1_rangeproof_rewind(ctx, vbf_out.buf, &value_out,
-                            msg.buf, &msglenout,
+    int res = secp256k1_rangeproof_rewind(ctx, (unsigned char *)vbf_out.buf,
+                            &value_out, (unsigned char *)msg.buf, &msglenout,
                             nonce.buf, &min_value, &max_value,
                             value_commitment.buf, proof.buf, proof.len,
                             script_pubkey.buf, script_pubkey.len,
@@ -1886,8 +1885,9 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
     uint64_t min_value;
     uint64_t max_value;
 
-    int res = secp256k1_rangeproof_rewind_preallocated(ctx, vbf_out.buf, &value_out,
-                            msg.buf, &msglenout,
+    int res = secp256k1_rangeproof_rewind_preallocated(ctx,
+                            (unsigned char *)vbf_out.buf, &value_out,
+                            (unsigned char *)msg.buf, &msglenout,
                             nonce.buf, &min_value, &max_value,
                             value_commitment.buf, (void*)memptr, prooflen,
                             script_pubkey.buf, script_pubkey.len,

--- a/mpy/libsecp256k1.c
+++ b/mpy/libsecp256k1.c
@@ -19,6 +19,7 @@
 #include "py/stream.h"
 #include "rangeproof_preallocated/rangeproof_preallocated.h"
 
+#if MODULE_SECP256K1_ENABLED
 
 #define malloc(b) gc_alloc((b), false)
 #define free gc_free
@@ -51,12 +52,12 @@ STATIC mp_obj_t usecp256k1_context_randomize(const mp_obj_t seed){
     mp_buffer_info_t seedbuf;
     mp_get_buffer_raise(seed, &seedbuf, MP_BUFFER_READ);
     if(seedbuf.len != 32){
-        mp_raise_ValueError("Seed should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Seed should be 32 bytes long"));
         return mp_const_none;
     }
     int res = secp256k1_context_randomize(ctx, seedbuf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to randomize context");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to randomize context"));
         return mp_const_none;
     }
     return mp_const_none;
@@ -69,20 +70,20 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_create(const mp_obj_t arg){
     mp_buffer_info_t secretbuf;
     mp_get_buffer_raise(arg, &secretbuf, MP_BUFFER_READ);
     if(secretbuf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pubkey;
     int res = secp256k1_ec_pubkey_create(ctx, &pubkey, secretbuf.buf);
     if(!res){
-        mp_raise_ValueError("Invalid private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Invalid private key"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, pubkey.data, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_create_obj, usecp256k1_ec_pubkey_create);
@@ -93,20 +94,20 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_parse(const mp_obj_t arg){
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(arg, &secbuf, MP_BUFFER_READ);
     if(secbuf.len != 33 && secbuf.len != 65){
-        mp_raise_ValueError("Serialized pubkey should be 33 or 65 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Serialized pubkey should be 33 or 65 bytes long"));
         return mp_const_none;
     }
     byte * buf = (byte*)secbuf.buf;
     switch(secbuf.len){
         case 33:
             if(buf[0] != 0x02 && buf[0] != 0x03){
-                mp_raise_ValueError("Compressed pubkey should start with 0x02 or 0x03");
+                mp_raise_ValueError(MP_ERROR_TEXT("Compressed pubkey should start with 0x02 or 0x03"));
                 return mp_const_none;
             }
             break;
         case 65:
             if(buf[0] != 0x04){
-                mp_raise_ValueError("Uncompressed pubkey should start with 0x04");
+                mp_raise_ValueError(MP_ERROR_TEXT("Uncompressed pubkey should start with 0x04"));
                 return mp_const_none;
             }
             break;
@@ -114,14 +115,14 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_parse(const mp_obj_t arg){
     secp256k1_pubkey pubkey;
     int res = secp256k1_ec_pubkey_parse(ctx, &pubkey, secbuf.buf, secbuf.len);
     if(!res){
-        mp_raise_ValueError("Failed parsing public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed parsing public key"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, pubkey.data, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_parse_obj, usecp256k1_ec_pubkey_parse);
@@ -132,7 +133,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_serialize(mp_uint_t n_args, const mp_obj_t 
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(args[0], &pubbuf, MP_BUFFER_READ);
     if(pubbuf.len != 64){
-        mp_raise_ValueError("Pubkey should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Pubkey should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pubkey;
@@ -145,13 +146,13 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_serialize(mp_uint_t n_args, const mp_obj_t 
     size_t len = 65;
     int res = secp256k1_ec_pubkey_serialize(ctx, out, &len, &pubkey, flag);
     if(!res){
-        mp_raise_ValueError("Failed serializing public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed serializing public key"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, len);
     memcpy((byte*)vstr.buf, out, len);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_serialize_obj, 1, usecp256k1_ec_pubkey_serialize);
@@ -162,20 +163,20 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_compact(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Compact signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Compact signature should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
     int res = secp256k1_ecdsa_signature_parse_compact(ctx, &sig, buf.buf);
     if(!res){
-        mp_raise_ValueError("Failed parsing compact signature");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed parsing compact signature"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, sig.data, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_compact_obj, usecp256k1_ecdsa_signature_parse_compact);
@@ -188,14 +189,14 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_parse_der(const mp_obj_t arg){
     secp256k1_ecdsa_signature sig;
     int res = secp256k1_ecdsa_signature_parse_der(ctx, &sig, buf.buf, buf.len);
     if(!res){
-        mp_raise_ValueError("Failed parsing der signature");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed parsing der signature"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, sig.data, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_parse_der_obj, usecp256k1_ecdsa_signature_parse_der);
@@ -206,7 +207,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_der(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Signature should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
@@ -215,14 +216,14 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_der(const mp_obj_t arg){
     size_t len = 78;
     int res = secp256k1_ecdsa_signature_serialize_der(ctx, out, &len, &sig);
     if(!res){
-        mp_raise_ValueError("Failed serializing der signature");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed serializing der signature"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, len);
     memcpy((byte*)vstr.buf, out, len);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_der_obj, usecp256k1_ecdsa_signature_serialize_der);
@@ -233,7 +234,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_compact(const mp_obj_t arg)
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Signature should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
@@ -241,7 +242,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_serialize_compact(const mp_obj_t arg)
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     secp256k1_ecdsa_signature_serialize_compact(ctx, (byte*)vstr.buf, &sig);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_serialize_compact_obj, usecp256k1_ecdsa_signature_serialize_compact);
@@ -252,7 +253,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t ms
     mp_buffer_info_t buf;
     mp_get_buffer_raise(sigarg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Signature should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
@@ -260,7 +261,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t ms
 
     mp_get_buffer_raise(msgarg, &buf, MP_BUFFER_READ);
     if(buf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
     byte msg[32];
@@ -268,7 +269,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_verify(const mp_obj_t sigarg, const mp_obj_t ms
 
     mp_get_buffer_raise(pubkeyarg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pub;
@@ -289,7 +290,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_normalize(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Signature should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
@@ -299,7 +300,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_signature_normalize(const mp_obj_t arg){
     vstr_init_len(&vstr, 64);
     secp256k1_ecdsa_signature_normalize(ctx, &sig2, &sig);
     memcpy(vstr.buf, sig2.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ecdsa_signature_normalize_obj, usecp256k1_ecdsa_signature_normalize);
@@ -309,13 +310,13 @@ STATIC mp_obj_t usecp256k1_nonce_function_default(mp_uint_t n_args, const mp_obj
     mp_buffer_info_t msgbuf;
     mp_get_buffer_raise(args[0], &msgbuf, MP_BUFFER_READ);
     if(msgbuf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(args[1], &secbuf, MP_BUFFER_READ);
     if(secbuf.len != 32){
-        mp_raise_ValueError("Secret should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Secret should be 32 bytes long"));
         return mp_const_none;
     }
     unsigned char *algo16 = NULL;
@@ -344,10 +345,10 @@ STATIC mp_obj_t usecp256k1_nonce_function_default(mp_uint_t n_args, const mp_obj
     }
     int res = secp256k1_nonce_function_default((unsigned char*)nonce.buf, msgbuf.buf, secbuf.buf, algo16, data, attempt);
     if(!res){
-        mp_raise_ValueError("Failed to calculate nonce");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to calculate nonce"));
         return mp_const_none;
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &nonce);
+    return mp_obj_new_bytes_from_vstr(&nonce);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_nonce_function_default_obj, 2, usecp256k1_nonce_function_default);
 
@@ -366,12 +367,12 @@ STATIC int usecp256k1_nonce_function(
     return secp256k1_nonce_function_default(nonce32, msg32, key32, algo16, data, attempt);
     // TODO: make nonce function compatible with ctypes
     // if(!mp_obj_is_callable(mp_nonce_callback)){
-    //     mp_raise_ValueError("Nonce callback should be callable...");
+    //     mp_raise_ValueError(MP_ERROR_TEXT("Nonce callback should be callable..."));
     //     return mp_const_none;
     // }
 
     // if(attempt > 100){
-    //     mp_raise_ValueError("Too many attempts... Invalid function?");
+    //     mp_raise_ValueError(MP_ERROR_TEXT("Too many attempts... Invalid function?"));
     //     // not sure it will ever get here, but just in case
     //     return secp256k1_nonce_function_default(nonce32, msg32, key32, algo16, data, attempt);
     // }
@@ -399,7 +400,7 @@ STATIC int usecp256k1_nonce_function(
     //     return 0;
     // }
     // if(buffer_info.len < 32){
-    //     mp_raise_ValueError("Returned nonce is less than 32 bytes");
+    //     mp_raise_ValueError(MP_ERROR_TEXT("Returned nonce is less than 32 bytes"));
     //     return 0;
     // }
     // memcpy(nonce32, (byte*)buffer_info.buf, 32);
@@ -411,20 +412,20 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
-        mp_raise_ValueError("Function requires at least two arguments: message and private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least two arguments: message and private key"));
         return mp_const_none;
     }
     mp_buffer_info_t msgbuf;
     mp_get_buffer_raise(args[0], &msgbuf, MP_BUFFER_READ);
     if(msgbuf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(args[1], &secbuf, MP_BUFFER_READ);
     if(secbuf.len != 32){
-        mp_raise_ValueError("Secret key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Secret key should be 32 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_signature sig;
@@ -440,7 +441,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
         if(n_args > 3){
             mp_get_buffer_raise(args[3], &databuf, MP_BUFFER_READ);
             if(databuf.len != 32){
-                mp_raise_ValueError("Data should be 32 bytes long");
+                mp_raise_ValueError(MP_ERROR_TEXT("Data should be 32 bytes long"));
                 return mp_const_none;
             }
             data = databuf.buf;
@@ -448,7 +449,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
         res = secp256k1_ecdsa_sign(ctx, &sig, msgbuf.buf, secbuf.buf, usecp256k1_nonce_function, data);
     }
     if(!res){
-        mp_raise_ValueError("Failed to sign");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to sign"));
         return mp_const_none;
     }
 
@@ -456,7 +457,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign(mp_uint_t n_args, const mp_obj_t *args){
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, sig.data, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_obj, 2, usecp256k1_ecdsa_sign);
 
@@ -466,7 +467,7 @@ STATIC mp_obj_t usecp256k1_ec_seckey_verify(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -485,7 +486,7 @@ STATIC mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -495,10 +496,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_negate(mp_obj_t arg){
 
     int res = secp256k1_ec_privkey_negate(ctx, vstr.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to negate the private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to negate the private key"));
         return mp_const_none;
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_privkey_negate_obj, usecp256k1_ec_privkey_negate);
@@ -509,7 +510,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_negate(mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Publick key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Publick key should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -519,10 +520,10 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_negate(mp_obj_t arg){
 
     int res = secp256k1_ec_pubkey_negate(ctx, (secp256k1_pubkey *)vstr.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to negate the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to negate the public key"));
         return mp_const_none;
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_ec_pubkey_negate_obj, usecp256k1_ec_pubkey_negate);
@@ -533,20 +534,20 @@ STATIC mp_obj_t usecp256k1_ec_privkey_tweak_add(mp_obj_t privarg, const mp_obj_t
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
     if(privbuf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
     int res = secp256k1_ec_privkey_tweak_add(ctx, privbuf.buf, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the private key"));
         return mp_const_none;
     }
     return mp_const_none;
@@ -560,14 +561,14 @@ STATIC mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweak
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
     if(privbuf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -577,10 +578,10 @@ STATIC mp_obj_t usecp256k1_ec_privkey_add(mp_obj_t privarg, const mp_obj_t tweak
 
     int res = secp256k1_ec_privkey_tweak_add(ctx, priv2.buf, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the private key"));
         return mp_const_none;
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &priv2);
+    return mp_obj_new_bytes_from_vstr(&priv2);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_privkey_add_obj, usecp256k1_ec_privkey_add);
@@ -591,7 +592,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_add(mp_obj_t pubarg, const mp_obj_t t
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
     if(pubbuf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pub;
@@ -600,13 +601,13 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_add(mp_obj_t pubarg, const mp_obj_t t
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
     int res = secp256k1_ec_pubkey_tweak_add(ctx, &pub, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the public key"));
         return mp_const_none;
     }
     memcpy(pubbuf.buf, pub.data, 64);
@@ -621,7 +622,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_add(mp_obj_t pubarg, const mp_obj_t tweakar
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
     if(pubbuf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pub;
@@ -630,20 +631,20 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_add(mp_obj_t pubarg, const mp_obj_t tweakar
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
     int res = secp256k1_ec_pubkey_tweak_add(ctx, &pub, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the public key"));
         return mp_const_none;
     }
 
     vstr_t pubbuf2;
     vstr_init_len(&pubbuf2, 64);
     memcpy((byte*)pubbuf2.buf, pub.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &pubbuf2);
+    return mp_obj_new_bytes_from_vstr(&pubbuf2);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_ec_pubkey_add_obj, usecp256k1_ec_pubkey_add);
@@ -654,20 +655,20 @@ STATIC mp_obj_t usecp256k1_ec_privkey_tweak_mul(mp_obj_t privarg, const mp_obj_t
     mp_buffer_info_t privbuf;
     mp_get_buffer_raise(privarg, &privbuf, MP_BUFFER_READ);
     if(privbuf.len != 32){
-        mp_raise_ValueError("Private key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Private key should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
     int res = secp256k1_ec_privkey_tweak_mul(ctx, privbuf.buf, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the public key"));
         return mp_const_none;
     }
     return mp_const_none;
@@ -681,7 +682,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_mul(mp_obj_t pubarg, const mp_obj_t t
     mp_buffer_info_t pubbuf;
     mp_get_buffer_raise(pubarg, &pubbuf, MP_BUFFER_READ);
     if(pubbuf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pubkey pub;
@@ -690,13 +691,13 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_tweak_mul(mp_obj_t pubarg, const mp_obj_t t
     mp_buffer_info_t tweakbuf;
     mp_get_buffer_raise(tweakarg, &tweakbuf, MP_BUFFER_READ);
     if(tweakbuf.len != 32){
-        mp_raise_ValueError("Tweak should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Tweak should be 32 bytes long"));
         return mp_const_none;
     }
 
     int res = secp256k1_ec_pubkey_tweak_mul(ctx, &pub, tweakbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to tweak the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to tweak the public key"));
         return mp_const_none;
     }
     memcpy(pubbuf.buf, pub.data, 64);
@@ -719,7 +720,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *a
                 free(pubkeys[j]);
             }
             free(pubkeys);
-            mp_raise_ValueError("All pubkeys should be 64 bytes long");
+            mp_raise_ValueError(MP_ERROR_TEXT("All pubkeys should be 64 bytes long"));
             return mp_const_none;
         }
         pubkeys[i] = (secp256k1_pubkey *)malloc(64);
@@ -727,7 +728,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *a
     }
     int res = secp256k1_ec_pubkey_combine(ctx, &pubkey, (const secp256k1_pubkey *const *)pubkeys, n_args);
     if(!res){
-        mp_raise_ValueError("Failed combining public keys");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed combining public keys"));
         return mp_const_none;
     }
     vstr_t vstr;
@@ -737,7 +738,7 @@ STATIC mp_obj_t usecp256k1_ec_pubkey_combine(mp_uint_t n_args, const mp_obj_t *a
         free(pubkeys[i]);
     }
     free(pubkeys);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ec_pubkey_combine_obj, 2, usecp256k1_ec_pubkey_combine);
@@ -749,7 +750,7 @@ STATIC mp_obj_t usecp256k1_xonly_pubkey_from_pubkey(mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -759,12 +760,12 @@ STATIC mp_obj_t usecp256k1_xonly_pubkey_from_pubkey(mp_obj_t arg){
 
     int res = secp256k1_xonly_pubkey_from_pubkey(ctx, (secp256k1_xonly_pubkey *)vstr.buf, &parity, buf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to convert the public key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to convert the public key"));
         return mp_const_none;
     }
 
     mp_obj_t items[2];
-    items[0] = mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    items[0] = mp_obj_new_bytes_from_vstr(&vstr);
     items[1] = mp_obj_new_int(parity);
     return mp_obj_new_tuple(2, items);
 }
@@ -777,7 +778,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj
     mp_buffer_info_t buf;
     mp_get_buffer_raise(sigarg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Signature should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Signature should be 64 bytes long"));
         return mp_const_none;
     }
     byte sig[64];
@@ -785,7 +786,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj
 
     mp_get_buffer_raise(msgarg, &buf, MP_BUFFER_READ);
     if(buf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
     byte msg[32];
@@ -793,7 +794,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_verify(const mp_obj_t sigarg, const mp_obj
 
     mp_get_buffer_raise(pubkeyarg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Public key should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Public key should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_xonly_pubkey pub;
@@ -814,7 +815,7 @@ STATIC mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 32){
-        mp_raise_ValueError("Secret should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Secret should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -824,11 +825,11 @@ STATIC mp_obj_t usecp256k1_keypair_create(mp_obj_t arg){
 
     int res = secp256k1_keypair_create(ctx, (secp256k1_keypair *)vstr.buf, buf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to create keypair");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to create keypair"));
         return mp_const_none;
     }
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_keypair_create_obj, usecp256k1_keypair_create);
 
@@ -838,27 +839,27 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
-        mp_raise_ValueError("Function requires at least two arguments: message and private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least two arguments: message and private key"));
         return mp_const_none;
     }
     mp_buffer_info_t msgbuf;
     mp_get_buffer_raise(args[0], &msgbuf, MP_BUFFER_READ);
     if(msgbuf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(args[1], &secbuf, MP_BUFFER_READ);
     if(secbuf.len != 32 && secbuf.len != 96){
-        mp_raise_ValueError("Secret key should be 32 bytes long or 96 bytes long (keypair)");
+        mp_raise_ValueError(MP_ERROR_TEXT("Secret key should be 32 bytes long or 96 bytes long (keypair)"));
         return mp_const_none;
     }
     byte keypair[96];
     if(secbuf.len == 32){
         int res = secp256k1_keypair_create(ctx, (secp256k1_keypair *)keypair, secbuf.buf);
         if(!res){
-            mp_raise_ValueError("Failed to create keypair");
+            mp_raise_ValueError(MP_ERROR_TEXT("Failed to create keypair"));
             return mp_const_none;
         }
     }else{
@@ -877,7 +878,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
         if(n_args > 3){
             mp_get_buffer_raise(args[3], &databuf, MP_BUFFER_READ);
             if(databuf.len != 32){
-                mp_raise_ValueError("Data should be 32 bytes long");
+                mp_raise_ValueError(MP_ERROR_TEXT("Data should be 32 bytes long"));
                 return mp_const_none;
             }
             data = databuf.buf;
@@ -885,7 +886,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
         res = secp256k1_schnorrsig_sign(ctx, sig, msgbuf.buf, (secp256k1_keypair *)keypair, NULL, data);
     }
     if(!res){
-        mp_raise_ValueError("Failed to sign");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to sign"));
         return mp_const_none;
     }
 
@@ -893,7 +894,7 @@ STATIC mp_obj_t usecp256k1_schnorrsig_sign(mp_uint_t n_args, const mp_obj_t *arg
     vstr_init_len(&vstr, 64);
     memcpy((byte*)vstr.buf, sig, 64);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_schnorrsig_sign_obj, 2, usecp256k1_schnorrsig_sign);
@@ -905,20 +906,20 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj
     maybe_init_ctx();
     mp_nonce_data = NULL;
     if(n_args < 2){
-        mp_raise_ValueError("Function requires at least two arguments: message and private key");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least two arguments: message and private key"));
         return mp_const_none;
     }
     mp_buffer_info_t msgbuf;
     mp_get_buffer_raise(args[0], &msgbuf, MP_BUFFER_READ);
     if(msgbuf.len != 32){
-        mp_raise_ValueError("Message should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Message should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t secbuf;
     mp_get_buffer_raise(args[1], &secbuf, MP_BUFFER_READ);
     if(secbuf.len != 32){
-        mp_raise_ValueError("Secret key should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Secret key should be 32 bytes long"));
         return mp_const_none;
     }
     secp256k1_ecdsa_recoverable_signature sig;
@@ -934,7 +935,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj
         if(n_args > 3){
             mp_get_buffer_raise(args[3], &databuf, MP_BUFFER_READ);
             if(databuf.len != 32){
-                mp_raise_ValueError("Data should be 32 bytes long");
+                mp_raise_ValueError(MP_ERROR_TEXT("Data should be 32 bytes long"));
                 return mp_const_none;
             }
             data = databuf.buf;
@@ -942,7 +943,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj
         res = secp256k1_ecdsa_sign_recoverable(ctx, &sig, msgbuf.buf, secbuf.buf, usecp256k1_nonce_function, data);
     }
     if(!res){
-        mp_raise_ValueError("Failed to sign");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to sign"));
         return mp_const_none;
     }
 
@@ -950,7 +951,7 @@ STATIC mp_obj_t usecp256k1_ecdsa_sign_recoverable(mp_uint_t n_args, const mp_obj
     vstr_init_len(&vstr, 65);
     memcpy((byte*)vstr.buf, sig.data, 65);
 
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_ecdsa_sign_recoverable_obj, 2, usecp256k1_ecdsa_sign_recoverable);
 
@@ -961,14 +962,14 @@ STATIC mp_obj_t usecp256k1_generator_generate_blinded(const mp_obj_t assetarg, c
     mp_buffer_info_t assetbuf;
     mp_get_buffer_raise(assetarg, &assetbuf, MP_BUFFER_READ);
     if(assetbuf.len != 32){
-        mp_raise_ValueError("Asset should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Asset should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t abfbuf;
     mp_get_buffer_raise(abfarg, &abfbuf, MP_BUFFER_READ);
     if(abfbuf.len != 32){
-        mp_raise_ValueError("Blinding factor should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Blinding factor should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -976,13 +977,13 @@ STATIC mp_obj_t usecp256k1_generator_generate_blinded(const mp_obj_t assetarg, c
 
     int res = secp256k1_generator_generate_blinded(ctx, &gen, assetbuf.buf, abfbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to generate generator");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to generate generator"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy(vstr.buf, gen.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(usecp256k1_generator_generate_blinded_obj, usecp256k1_generator_generate_blinded);
@@ -992,7 +993,7 @@ STATIC mp_obj_t usecp256k1_generator_generate(const mp_obj_t assetarg){
     mp_buffer_info_t assetbuf;
     mp_get_buffer_raise(assetarg, &assetbuf, MP_BUFFER_READ);
     if(assetbuf.len != 32){
-        mp_raise_ValueError("Asset should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Asset should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -1000,13 +1001,13 @@ STATIC mp_obj_t usecp256k1_generator_generate(const mp_obj_t assetarg){
 
     int res = secp256k1_generator_generate(ctx, &gen, assetbuf.buf);
     if(!res){ // never happens according to the API
-        mp_raise_ValueError("Failed to generate generator");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to generate generator"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy(vstr.buf, gen.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_generate_obj, usecp256k1_generator_generate);
@@ -1017,7 +1018,7 @@ STATIC mp_obj_t usecp256k1_generator_serialize(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Generator should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Generator should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_generator gen = { 0 };
@@ -1025,7 +1026,7 @@ STATIC mp_obj_t usecp256k1_generator_serialize(const mp_obj_t arg){
     vstr_t vstr;
     vstr_init_len(&vstr, 33);
     secp256k1_generator_serialize(ctx, (byte*)vstr.buf, &gen);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_serialize_obj, usecp256k1_generator_serialize);
@@ -1035,19 +1036,19 @@ STATIC mp_obj_t usecp256k1_generator_parse(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 33){
-        mp_raise_ValueError("Serialized generator should be 33 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Serialized generator should be 33 bytes long"));
         return mp_const_none;
     }
     secp256k1_generator gen = { 0 };
     int res = secp256k1_generator_parse(ctx, &gen, buf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to parse commitment");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to parse commitment"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy(vstr.buf, gen.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_generator_parse_obj, usecp256k1_generator_parse);
@@ -1058,19 +1059,19 @@ STATIC mp_obj_t usecp256k1_pedersen_commit(const mp_obj_t blindarg, mp_obj_t val
     mp_buffer_info_t blindbuf;
     mp_get_buffer_raise(blindarg, &blindbuf, MP_BUFFER_READ);
     if(blindbuf.len != 32){
-        mp_raise_ValueError("Blinding factor should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Blinding factor should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t genbuf;
     mp_get_buffer_raise(genarg, &genbuf, MP_BUFFER_READ);
     if(genbuf.len != 64){
-        mp_raise_ValueError("Generator should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Generator should be 64 bytes long"));
         return mp_const_none;
     }
 
     if(!mp_obj_is_int(valuearg)){
-        mp_raise_ValueError("Not int");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
         return mp_const_none;
     }
     uint64_t value = 0;
@@ -1100,13 +1101,13 @@ STATIC mp_obj_t usecp256k1_pedersen_commit(const mp_obj_t blindarg, mp_obj_t val
 
     int res = secp256k1_pedersen_commit(ctx, &commit, blindbuf.buf, value, genbuf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to create commitment");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to create commitment"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy(vstr.buf, commit.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_3(usecp256k1_pedersen_commit_obj, usecp256k1_pedersen_commit);
@@ -1116,7 +1117,7 @@ STATIC mp_obj_t usecp256k1_pedersen_commitment_serialize(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 64){
-        mp_raise_ValueError("Pedersen commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Pedersen commitment should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pedersen_commitment gen = { 0 };
@@ -1124,7 +1125,7 @@ STATIC mp_obj_t usecp256k1_pedersen_commitment_serialize(const mp_obj_t arg){
     vstr_t vstr;
     vstr_init_len(&vstr, 33);
     secp256k1_pedersen_commitment_serialize(ctx, (byte*)vstr.buf, &gen);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_serialize_obj, usecp256k1_pedersen_commitment_serialize);
@@ -1135,19 +1136,19 @@ STATIC mp_obj_t usecp256k1_pedersen_commitment_parse(const mp_obj_t arg){
     mp_buffer_info_t buf;
     mp_get_buffer_raise(arg, &buf, MP_BUFFER_READ);
     if(buf.len != 33){
-        mp_raise_ValueError("Serialized pedersen commitment should be 33 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Serialized pedersen commitment should be 33 bytes long"));
         return mp_const_none;
     }
     secp256k1_pedersen_commitment gen = { 0 };
     int res = secp256k1_pedersen_commitment_parse(ctx, &gen, buf.buf);
     if(!res){
-        mp_raise_ValueError("Failed to parse commitment");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to parse commitment"));
         return mp_const_none;
     }
     vstr_t vstr;
     vstr_init_len(&vstr, 64);
     memcpy(vstr.buf, gen.data, 64);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_pedersen_commitment_parse_obj, usecp256k1_pedersen_commitment_parse);
@@ -1183,16 +1184,16 @@ STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, 
     size_t n_total = (size_t)vals->len;
 
     if(!mp_obj_is_int(args[3])){
-        mp_raise_ValueError("Not an int");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not an int"));
         return 0;
     }
     size_t n_inputs = (size_t)get_uint64(args[3]);
     if(n_total < 0){
-        mp_raise_ValueError("meh");
+        mp_raise_ValueError(MP_ERROR_TEXT("meh"));
         return mp_const_none;
     }
     if(abfs->len != vals->len || vbfs->len != vals->len){
-        mp_raise_ValueError("Arrays should have the same len");
+        mp_raise_ValueError(MP_ERROR_TEXT("Arrays should have the same len"));
         return mp_const_none;
     }
     vstr_t vstr;
@@ -1200,16 +1201,16 @@ STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, 
     for(int i=0; i<n_inputs; i++){
         mp_get_buffer_raise(abfs->items[i], &buf, MP_BUFFER_READ);
         if(buf.len != 32){
-            mp_raise_ValueError("Invalid abf length");
+            mp_raise_ValueError(MP_ERROR_TEXT("Invalid abf length"));
             return mp_const_none;
         }
         mp_get_buffer_raise(vbfs->items[i], &buf, MP_BUFFER_READ);
         if(buf.len != 32){
-            mp_raise_ValueError("Invalid vbf length");
+            mp_raise_ValueError(MP_ERROR_TEXT("Invalid vbf length"));
             return mp_const_none;
         }
         if(!mp_obj_is_int(vals->items[i])){
-            mp_raise_ValueError("Not an int");
+            mp_raise_ValueError(MP_ERROR_TEXT("Not an int"));
             return 0;
         }
     }
@@ -1237,10 +1238,10 @@ STATIC mp_obj_t usecp256k1_pedersen_blind_generator_blind_sum(mp_uint_t n_args, 
     free(gens);
     free(bfactors);
     if(!res){
-        mp_raise_ValueError("Failed to calculate sum");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to calculate sum"));
         return mp_const_none;
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_pedersen_blind_generator_blind_sum_obj, 4, usecp256k1_pedersen_blind_generator_blind_sum);
@@ -1255,7 +1256,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp
     mp_buffer_info_t in_assets_buf;
     if(mp_get_buffer(args[0], &in_assets_buf, MP_BUFFER_READ)){
         if(in_assets_buf.len % sizeof(secp256k1_fixed_asset_tag) != 0){
-            mp_raise_ValueError("Invalid length of assets");
+            mp_raise_ValueError(MP_ERROR_TEXT("Invalid length of assets"));
             return mp_const_none;
         }
         in_assets_ptr = (secp256k1_fixed_asset_tag *)in_assets_buf.buf;
@@ -1267,7 +1268,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp
     mp_buffer_info_t seed;
     mp_get_buffer_raise(args[2], &seed, MP_BUFFER_READ);
     if(asset.len != sizeof(secp256k1_fixed_asset_tag) || seed.len != 32){
-        mp_raise_ValueError("Invalid argument length");
+        mp_raise_ValueError(MP_ERROR_TEXT("Invalid argument length"));
         return mp_const_none;
     }
 
@@ -1293,7 +1294,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp
         for(int i=0; i<n_inputs; i++){
             mp_get_buffer_raise(in_assets->items[i], &buf, MP_BUFFER_READ);
             if(buf.len != 32){
-                mp_raise_ValueError("Invalid argument length");
+                mp_raise_ValueError(MP_ERROR_TEXT("Invalid argument length"));
                 return mp_const_none;
             }
         }
@@ -1308,11 +1309,11 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize(mp_uint_t n_args, const mp
         free(in_assets_ptr);
     }
     if(!res){
-        mp_raise_ValueError("Failed to initialize surj proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to initialize surj proof"));
         return mp_const_none;
     }
     mp_obj_t items[2];
-    items[0] = mp_obj_new_str_from_vstr(&mp_type_bytes, &proof);
+    items[0] = mp_obj_new_bytes_from_vstr(&proof);
     items[1] = mp_obj_new_int_from_ull(input_index);
     return mp_obj_new_tuple(2, items);
 }
@@ -1326,14 +1327,14 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_a
     intptr_t proofptr = get_uint64(args[0]);
     size_t prooflen = get_uint64(args[1]);
     if(prooflen < sizeof(secp256k1_surjectionproof)){
-        mp_raise_ValueError("Not enough memory preallocated");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not enough memory preallocated"));
     }
     secp256k1_fixed_asset_tag * in_assets_ptr = NULL;
     mp_obj_list_t *in_assets = NULL;
     mp_buffer_info_t in_assets_buf;
     if(mp_get_buffer(args[2], &in_assets_buf, MP_BUFFER_READ)){
         if(in_assets_buf.len % sizeof(secp256k1_fixed_asset_tag) != 0){
-            mp_raise_ValueError("Invalid length of assets");
+            mp_raise_ValueError(MP_ERROR_TEXT("Invalid length of assets"));
             return mp_const_none;
         }
         in_assets_ptr = (secp256k1_fixed_asset_tag *)in_assets_buf.buf;
@@ -1345,7 +1346,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_a
     mp_buffer_info_t seed;
     mp_get_buffer_raise(args[4], &seed, MP_BUFFER_READ);
     if(asset.len != sizeof(secp256k1_fixed_asset_tag) || seed.len != 32){
-        mp_raise_ValueError("Invalid argument length");
+        mp_raise_ValueError(MP_ERROR_TEXT("Invalid argument length"));
         return mp_const_none;
     }
 
@@ -1369,7 +1370,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_a
         for(int i=0; i<n_inputs; i++){
             mp_get_buffer_raise(in_assets->items[i], &buf, MP_BUFFER_READ);
             if(buf.len != 32){
-                mp_raise_ValueError("Invalid argument length");
+                mp_raise_ValueError(MP_ERROR_TEXT("Invalid argument length"));
                 return mp_const_none;
             }
         }
@@ -1384,7 +1385,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_initialize_preallocated(mp_uint_t n_a
         free(in_assets_ptr);
     }
     if(!res){
-        mp_raise_ValueError("Failed to initialize surj proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to initialize surj proof"));
         return mp_const_none;
     }
     mp_obj_t items[2];
@@ -1403,13 +1404,13 @@ STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_o
         ptr = (secp256k1_surjectionproof *)proof.buf;
     }else{
         if(!mp_obj_is_int(args[0])){
-            mp_raise_ValueError("Not int");
+            mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
             return mp_const_none;
         }
         ptr = (secp256k1_surjectionproof *)(intptr_t)get_uint64(args[0]);
     }
     if(!mp_obj_is_int(args[1])){
-        mp_raise_ValueError("Not int");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
         return mp_const_none;
     }
     size_t in_idx = (size_t)get_uint64(args[1]);
@@ -1421,7 +1422,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_o
     mp_buffer_info_t out_abf;
     mp_get_buffer_raise(args[5], &out_abf, MP_BUFFER_READ);
     if(out_abf.len != 32 || asset.len != sizeof(secp256k1_generator) || in_abf.len != 32){
-        mp_raise_ValueError("Invalid argument length");
+        mp_raise_ValueError(MP_ERROR_TEXT("Invalid argument length"));
         return mp_const_none;
     }
 
@@ -1431,7 +1432,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_o
     for(int i=0; i<n_inputs; i++){
         mp_get_buffer_raise(in_assets->items[i], &buf, MP_BUFFER_READ);
         if(buf.len != sizeof(secp256k1_generator)){
-            mp_raise_ValueError("Invalid gen argument length");
+            mp_raise_ValueError(MP_ERROR_TEXT("Invalid gen argument length"));
             return mp_const_none;
         }
     }
@@ -1443,7 +1444,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_generate(mp_uint_t n_args, const mp_o
     int res = secp256k1_surjectionproof_generate(ctx, ptr, in_assets_buf, n_inputs, (secp256k1_generator *)asset.buf, in_idx, in_abf.buf, out_abf.buf);
     free(in_assets_buf);
     if(!res){
-        mp_raise_ValueError("Failed to generate surj proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to generate surj proof"));
         return mp_const_none;
     }
     return args[0];
@@ -1459,7 +1460,7 @@ STATIC mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
         ptr = (secp256k1_surjectionproof *)proof.buf;
     }else{
         if(!mp_obj_is_int(arg)){
-            mp_raise_ValueError("Not int");
+            mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
             return mp_const_none;
         }
         ptr = (secp256k1_surjectionproof *)(intptr_t)get_uint64(arg);
@@ -1471,13 +1472,13 @@ STATIC mp_obj_t usecp256k1_surjectionproof_serialize(const mp_obj_t arg){
 
     int res = secp256k1_surjectionproof_serialize(ctx, vstr.buf, &l, ptr);
     if(!res){
-        mp_raise_ValueError("Failed to serialize surj proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to serialize surj proof"));
         return mp_const_none;
     }
     if(l < l0){
         vstr_cut_tail_bytes(&vstr, l0-l);
     }
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_surjectionproof_serialize_obj, usecp256k1_surjectionproof_serialize);
 
@@ -1485,18 +1486,18 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(usecp256k1_surjectionproof_serialize_obj, usecp
 STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 7){
-        mp_raise_ValueError("Function requires at least 7 arguments");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least 7 arguments"));
         return mp_const_none;
     }
     mp_buffer_info_t nonce;
     mp_get_buffer_raise(args[0], &nonce, MP_BUFFER_READ);
     if(nonce.len != 32){
-        mp_raise_ValueError("Nonce should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Nonce should be 32 bytes long"));
         return mp_const_none;
     }
 
     if(!mp_obj_is_int(args[1])){
-        mp_raise_ValueError("Not int");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
         return mp_const_none;
     }
     uint64_t value = get_uint64(args[1]);
@@ -1504,7 +1505,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     mp_buffer_info_t commitbuf;
     mp_get_buffer_raise(args[2], &commitbuf, MP_BUFFER_READ);
     if(commitbuf.len != 64){
-        mp_raise_ValueError("Commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Commitment should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pedersen_commitment commit = { 0 };
@@ -1513,7 +1514,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     mp_buffer_info_t vbf;
     mp_get_buffer_raise(args[3], &vbf, MP_BUFFER_READ);
     if(vbf.len != 32){
-        mp_raise_ValueError("Value blinding factor should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Value blinding factor should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -1526,7 +1527,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     mp_buffer_info_t genbuf;
     mp_get_buffer_raise(args[6], &genbuf, MP_BUFFER_READ);
     if(genbuf.len != 64){
-        mp_raise_ValueError("Commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Commitment should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_generator gen = { 0 };
@@ -1535,7 +1536,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
     uint64_t min_value = 1;
     if(n_args > 7){
         if(!mp_obj_is_int(args[7])){
-            mp_raise_ValueError("Not int");
+            mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
             return mp_const_none;
         }
         min_value = get_uint64(args[7]);
@@ -1560,11 +1561,11 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign(mp_uint_t n_args, const mp_obj_t *arg
                 min_value, &commit, vbf.buf, nonce.buf,
                 exp, min_bits, value, msg.buf, msg.len, extra.buf, extra.len, &gen);
     if(!res){
-        mp_raise_ValueError("Failed to create a proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to create a proof"));
         return mp_const_none;
     }
     vstr_cut_tail_bytes(&vstr, 5200-prooflen);
-    return mp_obj_new_str_from_vstr(&mp_type_bytes, &vstr);
+    return mp_obj_new_bytes_from_vstr(&vstr);
 }
 
 STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_obj, 7, usecp256k1_rangeproof_sign);
@@ -1574,7 +1575,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_obj, 7, usecp256k1
 STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 10){
-        mp_raise_ValueError("Function requires at least 10 arguments");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires at least 10 arguments"));
         return mp_const_none;
     }
     mp_obj_t stream = args[0];
@@ -1587,7 +1588,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     size_t prooflen = 5800;
 
     if(memlen < prooflen){
-        mp_raise_ValueError("Not enough memory for proof allocation.");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not enough memory for proof allocation."));
         return mp_const_none;
     }
     memset((void*) memptr, 0, prooflen);
@@ -1595,7 +1596,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     mp_buffer_info_t nonce;
     mp_get_buffer_raise(args[3], &nonce, MP_BUFFER_READ);
     if(nonce.len != 32){
-        mp_raise_ValueError("Nonce should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Nonce should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -1604,7 +1605,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     mp_buffer_info_t commitbuf;
     mp_get_buffer_raise(args[5], &commitbuf, MP_BUFFER_READ);
     if(commitbuf.len != 64){
-        mp_raise_ValueError("Commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Commitment should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_pedersen_commitment commit = { 0 };
@@ -1613,7 +1614,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     mp_buffer_info_t vbf;
     mp_get_buffer_raise(args[6], &vbf, MP_BUFFER_READ);
     if(vbf.len != 32){
-        mp_raise_ValueError("Value blinding factor should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Value blinding factor should be 32 bytes long"));
         return mp_const_none;
     }
 
@@ -1626,7 +1627,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
     mp_buffer_info_t genbuf;
     mp_get_buffer_raise(args[9], &genbuf, MP_BUFFER_READ);
     if(genbuf.len != 64){
-        mp_raise_ValueError("Commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Commitment should be 64 bytes long"));
         return mp_const_none;
     }
     secp256k1_generator gen = { 0 };
@@ -1655,7 +1656,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_sign_to(mp_uint_t n_args, const mp_obj_t *
                 exp, min_bits, value, msg.buf, msg.len, extra.buf, extra.len, &gen,
                 (void *)(memptr+prooflen), (memlen-prooflen));
     if(!res){
-        mp_raise_ValueError("Failed to create a proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to create a proof"));
         return mp_const_none;
     }
 
@@ -1676,7 +1677,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_sign_to_obj, 10, usecp2
 STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 5){
-        mp_raise_ValueError("Function requires 5 arguments");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires 5 arguments"));
         return mp_const_none;
     }
     mp_buffer_info_t proof;
@@ -1685,14 +1686,14 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *a
     mp_buffer_info_t nonce;
     mp_get_buffer_raise(args[1], &nonce, MP_BUFFER_READ);
     if(nonce.len != 32){
-        mp_raise_ValueError("Nonce should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Nonce should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t value_commitment;
     mp_get_buffer_raise(args[2], &value_commitment, MP_BUFFER_READ);
     if(value_commitment.len != 64){
-        mp_raise_ValueError("Value commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Value commitment should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1702,7 +1703,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *a
     mp_buffer_info_t generator;
     mp_get_buffer_raise(args[4], &generator, MP_BUFFER_READ);
     if(generator.len != 64){
-        mp_raise_ValueError("Generator should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Generator should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1729,21 +1730,21 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind(mp_uint_t n_args, const mp_obj_t *a
                             generator.buf);
 
     if(!res){
-        mp_raise_ValueError("Failed to rewind the proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to rewind the proof"));
         return mp_const_none;
     }
 
     // value_out, vbf_out, msg, min_value, max_value
     mp_obj_t items[5];
     items[0] = mp_obj_new_int_from_ull(value_out);
-    items[1] = mp_obj_new_str_from_vstr(&mp_type_bytes, &vbf_out);
+    items[1] = mp_obj_new_bytes_from_vstr(&vbf_out);
     if(msglen == msglenout){
-        items[2] = mp_obj_new_str_from_vstr(&mp_type_bytes, &msg);
+        items[2] = mp_obj_new_bytes_from_vstr(&msg);
     }else{
         vstr_t msgout;
         vstr_init_len(&msgout, msglenout);
         memcpy(msgout.buf, msg.buf, msglenout);
-        items[2] = mp_obj_new_str_from_vstr(&mp_type_bytes, &msgout);
+        items[2] = mp_obj_new_bytes_from_vstr(&msgout);
     }
     items[3] = mp_obj_new_int_from_ull(min_value);
     items[4] = mp_obj_new_int_from_ull(max_value);
@@ -1756,7 +1757,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_rewind_obj, 5, usecp256
 STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 4){
-        mp_raise_ValueError("Function requires 4 arguments");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires 4 arguments"));
         return mp_const_none;
     }
     mp_buffer_info_t proof;
@@ -1765,7 +1766,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *a
     mp_buffer_info_t value_commitment;
     mp_get_buffer_raise(args[1], &value_commitment, MP_BUFFER_READ);
     if(value_commitment.len != 64){
-        mp_raise_ValueError("Value commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Value commitment should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1775,7 +1776,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *a
     mp_buffer_info_t generator;
     mp_get_buffer_raise(args[3], &generator, MP_BUFFER_READ);
     if(generator.len != 64){
-        mp_raise_ValueError("Generator should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Generator should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1788,7 +1789,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_verify(mp_uint_t n_args, const mp_obj_t *a
                             generator.buf);
 
     if(!res){
-        mp_raise_ValueError("Failed to verify the proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to verify the proof"));
         return mp_const_none;
     }
 
@@ -1805,14 +1806,14 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_VAR(usecp256k1_rangeproof_verify_obj, 4, usecp256
 STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj_t *args){
     maybe_init_ctx();
     if(n_args < 8){
-        mp_raise_ValueError("Function requires 8 arguments");
+        mp_raise_ValueError(MP_ERROR_TEXT("Function requires 8 arguments"));
         return mp_const_none;
     }
     // stream to read
     mp_obj_t stream = args[0];
     mp_get_stream_raise(stream, MP_STREAM_OP_READ);
     if(!mp_obj_is_int(args[1])){
-        mp_raise_ValueError("Not int");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not int"));
         return mp_const_none;
     }
     size_t prooflen = (size_t)get_uint64(args[1]);
@@ -1825,21 +1826,21 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
 
     size_t l = 0;
     if(memlen < memoff){
-        mp_raise_ValueError("Not enough memory for proof.");
+        mp_raise_ValueError(MP_ERROR_TEXT("Not enough memory for proof."));
         return mp_const_none;
     }
     int err = 0;
     while(l < (prooflen - 64)){
         mp_stream_read_exactly(stream, (byte*)(memptr+l), 64, &err);
         if(err){
-            mp_raise_ValueError("Failed to read from stream");
+            mp_raise_ValueError(MP_ERROR_TEXT("Failed to read from stream"));
             return mp_const_none;
         }
         l += 64;
     }
     mp_stream_read_exactly(stream, (byte*)(memptr+l), (prooflen-l), &err);
     if(err){
-        mp_raise_ValueError("Failed to read from stream");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to read from stream"));
         return mp_const_none;
     }
 
@@ -1849,14 +1850,14 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
     mp_buffer_info_t nonce;
     mp_get_buffer_raise(args[4], &nonce, MP_BUFFER_READ);
     if(nonce.len != 32){
-        mp_raise_ValueError("Nonce should be 32 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Nonce should be 32 bytes long"));
         return mp_const_none;
     }
 
     mp_buffer_info_t value_commitment;
     mp_get_buffer_raise(args[5], &value_commitment, MP_BUFFER_READ);
     if(value_commitment.len != 64){
-        mp_raise_ValueError("Value commitment should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Value commitment should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1866,7 +1867,7 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
     mp_buffer_info_t generator;
     mp_get_buffer_raise(args[7], &generator, MP_BUFFER_READ);
     if(generator.len != 64){
-        mp_raise_ValueError("Generator should be 64 bytes long");
+        mp_raise_ValueError(MP_ERROR_TEXT("Generator should be 64 bytes long"));
         return mp_const_none;
     }
 
@@ -1893,21 +1894,21 @@ STATIC mp_obj_t usecp256k1_rangeproof_rewind_from(mp_uint_t n_args, const mp_obj
                             generator.buf, (void *)(memptr+memoff), (memlen-memoff));
 
     if(!res){
-        mp_raise_ValueError("Failed to rewind the proof");
+        mp_raise_ValueError(MP_ERROR_TEXT("Failed to rewind the proof"));
         return mp_const_none;
     }
 
     // value_out, vbf_out, msg, min_value, max_value
     mp_obj_t items[5];
     items[0] = mp_obj_new_int_from_ull(value_out);
-    items[1] = mp_obj_new_str_from_vstr(&mp_type_bytes, &vbf_out);
+    items[1] = mp_obj_new_bytes_from_vstr(&vbf_out);
     if(msglen == msglenout){
-        items[2] = mp_obj_new_str_from_vstr(&mp_type_bytes, &msg);
+        items[2] = mp_obj_new_bytes_from_vstr(&msg);
     }else{
         vstr_t msgout;
         vstr_init_len(&msgout, msglenout);
         memcpy(msgout.buf, msg.buf, msglenout);
-        items[2] = mp_obj_new_str_from_vstr(&mp_type_bytes, &msgout);
+        items[2] = mp_obj_new_bytes_from_vstr(&msgout);
     }
     items[3] = mp_obj_new_int_from_ull(min_value);
     items[4] = mp_obj_new_int_from_ull(max_value);
@@ -1988,4 +1989,6 @@ const mp_obj_module_t secp256k1_user_cmodule = {
 };
 
 // Register the module to make it available in Python
-MP_REGISTER_MODULE(MP_QSTR_secp256k1, secp256k1_user_cmodule, MODULE_SECP256K1_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_secp256k1, secp256k1_user_cmodule);
+
+#endif // MODULE_SECP256K1_ENABLED

--- a/secp256k1.lib
+++ b/secp256k1.lib
@@ -1,1 +1,1 @@
-https://github.com/bitcoin-core/secp256k1/#f39f99be0e6add959f534c03b93044cef066fe09
+https://github.com/BlockstreamResearch/secp256k1-zkp.git/#6152622613fdf1c5af6f31f74c427c4e9ee120ce


### PR DESCRIPTION
## 🚧 Work in Progress – Early Draft
This pull request is opened early to:

- Share current progress
- Gather feedback from contributors
- Discuss implementation approaches

💡 Note: This PR is not ready for review or merging. Some parts may be incomplete, untested, or non-buildable at this stage. Feel free to comment on design decisions, request clarifications, or suggest alternatives.

## Summary

This PR updates the `secp256k1` user C module to ensure compatibility with MicroPython v1.25. It addresses breaking changes introduced in the MicroPython API and refactors the module structure to align with the latest user C module guidelines.

## Changes

* WIP: The underlying library [secp256k1-zkp](https://github.com/BlockstreamResearch/secp256k1-zkp.git) being upgraded to [6152622](https://github.com/BlockstreamResearch/secp256k1-zkp/commit/6152622613fdf1c5af6f31f74c427c4e9ee120ce)
* Updated module initialization to match MicroPython v1.25 API
* Replaced deprecated macros and types with their v1.25 equivalents
* TODO: Ensure compatibility with the new module registration mechanism
* TODO: Cleanup of legacy code and unused includes
* TODO: Update `README.md` with v1.25-specific build instructions

## Testing

* TODO: Build the module against MicroPython v1.25 on Unix and STM32 ports without compilation errors
* TODO: Verify that `secp256k1` functions (`verify`, `sign`, `pubkey_create`, etc.) work as expected via REPL tests
* TODO: Add test script under `tests/usercmodules/secp256k1_test.py` with basic signing and verification use cases

## Checklist

* [ ] Code builds without errors
* [ ] Tests added or updated
* [ ] Documentation updated if necessary
* [ ] Code reviewed for security and edge cases